### PR TITLE
Properly handle non serializable exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": ">=5.4",
         "symfony/dependency-injection": "~2.3",
         "symfony/yaml": "~2.3",
-        "symfony/config": "~2.3"
+        "symfony/config": "~2.3",
+        "mockery/mockery": "~0.9"
     },
     "require-dev": {
         "symfony/console": "~2.3",

--- a/src/TestTools/Fixture/NonSerializableExceptionContainer.php
+++ b/src/TestTools/Fixture/NonSerializableExceptionContainer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace TestTools\Fixture;
+
+class NonSerializableExceptionContainer
+{
+    private $className;
+    private $message;
+    private $code;
+
+    public function __construct(\Exception $e)
+    {
+        $this->className = get_class($e);
+        $this->message   = $e->getMessage();
+        $this->code      = $e->getCode();
+    }
+
+    public function recreate()
+    {
+        $e = \Mockery::mock($this->className);
+        $e->makePartial();
+
+        $property = new \ReflectionProperty($this->className, "message");
+        $property->setAccessible(true);
+        $property->setValue($e, $this->message);
+        $property = new \ReflectionProperty($this->className, "code");
+        $property->setAccessible(true);
+        $property->setValue($e, $this->code);
+
+        return $e;
+    }
+}

--- a/src/TestTools/Tests/Fixture/FileFixtureTest.php
+++ b/src/TestTools/Tests/Fixture/FileFixtureTest.php
@@ -130,4 +130,20 @@ class FileFixtureTest extends UnitTestCase {
 
         $this->assertEquals($expected, $fixture->getResult());
     }
+
+    public function testNonSerializableExceptionIsReproducable()
+    {
+        $object = new NotSerializableException("testmessage", 42);
+        
+        $filename = $this->getFixturePath() . '/not_serializable_exception.fix';
+        $fixture = new FileFixture($filename);
+        $fixture->setResult($object);
+
+        $fixture->save();
+        
+        $result = $fixture->getResult();
+        $this->assertInstanceOf('TestTools\Tests\Fixture\NotSerializableException', $result);
+        $this->assertEquals("testmessage", $result->getMessage());
+        $this->assertEquals(42, $result->getCode());
+    }
 }

--- a/src/TestTools/Tests/Fixture/NotSerializableException.php
+++ b/src/TestTools/Tests/Fixture/NotSerializableException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace TestTools\Tests\Fixture;
+
+class NotSerializableException extends \Exception
+{
+    public function __sleep()
+    {
+        throw new \Exception ('Can not be serialized!');
+    }
+}


### PR DESCRIPTION
In case a (non serializable) database exception is thrown (failing constraints etc) the testtools would save it as an ordinary string (Result is not serializable print_r($result)).

Upon test replay this might (and happened in my case) change execution flow as an exception throw is not happening.
