### PR TITLE
Include full request to generate signature (X-Authentication headers and the like)

### DIFF
--- a/src/TestTools/Guzzle/Http/Request.php
+++ b/src/TestTools/Guzzle/Http/Request.php
@@ -20,7 +20,7 @@ class Request extends GuzzleRequest
             $body = $this->body;
         }
 
-        $fingerprint = sha1(serialize(array($body, $this->getUrl(), $this->getMethod(), $this->getQuery(true))));
+        $fingerprint = sha1(serialize((string)$this));
         return $this->callWithFixtures('send', array($fingerprint));
     }
 }


### PR DESCRIPTION
Standard use case:

Request with X-User-ID: 1 yields result 1
Request with X-User-ID: 2 yields result 2

Execute all unittests at once

Test 1 testing user id 1 will use result 1
Test 2 testing user id 2 will use result 1 (Query etc are all the same and headers are not taken into account when generating a signature) => fail

TestTools should include full headers to generate a signature. There is a convenient toString() method which generates the full request