### PR TITLE
travis: add PHP 7.1, drop default options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 before_script:
-  - composer install --dev
+  - composer install
 
-script: phpunit --configuration phpunit.xml.dist
+script:
+  - phpunit


### PR DESCRIPTION
- `--dev` is on by default
- `phpunit.xml.dist` is also loaded by default