### PR TITLE
Make use of PHP 7 strict_types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,21 +14,21 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
-        "symfony/dependency-injection": ">=2.8",
-        "symfony/yaml": ">=2.8",
-        "symfony/config": ">=2.8",
+        "php": ">=7.0",
+        "symfony/dependency-injection": "^2.8|^3.0",
+        "symfony/yaml": "^2.8|^3.0",
+        "symfony/config": "^2.8|^3.0",
         "mockery/mockery": "~0.9"
     },
     "require-dev": {
-        "symfony/console": ">=2.8",
-        "symfony/framework-bundle": ">=2.8",
+        "symfony/console": "^2.8|^3.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
         "doctrine/dbal": "~2.5",
         "guzzle/guzzle": "~3.9.2",
         "kriswallsmith/buzz": "~0.10",
         "basho/riak": "~2.0",
         "swiftmailer/swiftmailer": "5.*",
-        "phpunit/phpunit": ">=6.0"
+        "phpunit/phpunit": "^6.0"
     },
     "autoload": {
         "psr-4": { "TestTools\\": "src/" }

--- a/src/Basho/Riak.php
+++ b/src/Basho/Riak.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Basho;
 
 use Basho\Riak as BashoRiak;

--- a/src/Buzz/Client.php
+++ b/src/Buzz/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Buzz;
 
 use TestTools\Fixture\BlackBox;

--- a/src/Doctrine/DBAL/Connection.php
+++ b/src/Doctrine/DBAL/Connection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Doctrine\DBAL;
 
 use Closure;

--- a/src/Fixture/BlackBox.php
+++ b/src/Fixture/BlackBox.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture;
 
 use TestTools\Fixture\SelfInitializingFixtureTrait;

--- a/src/Fixture/Exception/FixtureEmptyFilenameException.php
+++ b/src/Fixture/Exception/FixtureEmptyFilenameException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture\Exception;
 
 class FixtureEmptyFilenameException extends FixtureException {

--- a/src/Fixture/Exception/FixtureException.php
+++ b/src/Fixture/Exception/FixtureException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture\Exception;
 
 class FixtureException extends \Exception {

--- a/src/Fixture/Exception/FixtureInvalidDirectoryException.php
+++ b/src/Fixture/Exception/FixtureInvalidDirectoryException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture\Exception;
 
 class FixtureInvalidDirectoryException extends FixtureException {

--- a/src/Fixture/Exception/FixtureNotFoundException.php
+++ b/src/Fixture/Exception/FixtureNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture\Exception;
 
 class FixtureNotFoundException extends FixtureException {

--- a/src/Fixture/Exception/FixtureNotValidException.php
+++ b/src/Fixture/Exception/FixtureNotValidException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture\Exception;
 
 class FixtureNotValidException extends FixtureNotFoundException {

--- a/src/Fixture/Exception/OfflineException.php
+++ b/src/Fixture/Exception/OfflineException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture\Exception;
 
 class OfflineException extends FixtureException {

--- a/src/Fixture/FileFixture.php
+++ b/src/Fixture/FileFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture;
 
 use TestTools\Fixture\Exception\FixtureEmptyFilenameException;

--- a/src/Fixture/NonSerializableExceptionContainer.php
+++ b/src/Fixture/NonSerializableExceptionContainer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture;
 
 class NonSerializableExceptionContainer

--- a/src/Fixture/SelfInitializingFixtureTrait.php
+++ b/src/Fixture/SelfInitializingFixtureTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Fixture;
 
 use TestTools\Fixture\FileFixture;

--- a/src/Guzzle/Http/EntityEnclosingRequest.php
+++ b/src/Guzzle/Http/EntityEnclosingRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Guzzle\Http;
 
 use Guzzle\Http\EntityBody;

--- a/src/Guzzle/Http/Request.php
+++ b/src/Guzzle/Http/Request.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Guzzle\Http;
 
 use Guzzle\Http\Message\Request as GuzzleRequest;

--- a/src/Guzzle/Http/RequestFactory.php
+++ b/src/Guzzle/Http/RequestFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Guzzle\Http;
 
 use Guzzle\Http\Message\RequestFactory as GuzzleRequestFactory;

--- a/src/Profiler/Profiler.php
+++ b/src/Profiler/Profiler.php
@@ -166,9 +166,9 @@ class Profiler
             if ($step['silent']) continue;
 
             $result .= self::padLabel($step['label'], $labelWidth) . ' '
-                . str_pad(round($step['total'] * 1000), 10, ' ', STR_PAD_LEFT) . ' '
-                . str_pad(number_format($step['diff'] * 1000, 1), 10, ' ', STR_PAD_LEFT) . ' '
-                . str_pad(number_format(($step['diff'] / $totalTime) * 100, 1), 10, ' ', STR_PAD_LEFT) . "\n";
+                . str_pad((string) round($step['total'] * 1000), 10, ' ', STR_PAD_LEFT) . ' '
+                . str_pad((string) number_format($step['diff'] * 1000, 1), 10, ' ', STR_PAD_LEFT) . ' '
+                . str_pad((string) number_format(($step['diff'] / $totalTime) * 100, 1), 10, ' ', STR_PAD_LEFT) . "\n";
         }
 
         if (count(self::$aggregated) > 0) {
@@ -182,17 +182,17 @@ class Profiler
                 if ($values['count'] == 0) continue;
 
                 $result .= self::padLabel($label, $labelWidth) . ' '
-                    . str_pad($values['count'], 10, ' ', STR_PAD_LEFT) . ' '
-                    . str_pad(number_format($values['total'] * 1000, 1), 10, ' ', STR_PAD_LEFT) . ' '
-                    . str_pad(number_format(($values['total'] / $totalTime) * 100, 1), 10, ' ', STR_PAD_LEFT) . "\n";
+                    . str_pad((string) $values['count'], 10, ' ', STR_PAD_LEFT) . ' '
+                    . str_pad((string) number_format($values['total'] * 1000, 1), 10, ' ', STR_PAD_LEFT) . ' '
+                    . str_pad((string) number_format(($values['total'] / $totalTime) * 100, 1), 10, ' ', STR_PAD_LEFT) . "\n";
 
                 ksort($values['sub']);
 
                 foreach ($values['sub'] as $sublabel => $subvalues) {
                     $result .= self::padSublabel($sublabel, $labelWidth) . ' '
-                        . str_pad($subvalues['count'], 10, ' ', STR_PAD_LEFT) . ' '
-                        . str_pad(number_format($subvalues['total'] * 1000, 1), 10, ' ', STR_PAD_LEFT) . ' '
-                        . str_pad(number_format(($subvalues['total'] / $totalTime) * 100, 1), 10, ' ', STR_PAD_LEFT) . "\n";
+                        . str_pad((string) $subvalues['count'], 10, ' ', STR_PAD_LEFT) . ' '
+                        . str_pad((string) number_format($subvalues['total'] * 1000, 1), 10, ' ', STR_PAD_LEFT) . ' '
+                        . str_pad((string) number_format(($subvalues['total'] / $totalTime) * 100, 1), 10, ' ', STR_PAD_LEFT) . "\n";
                 }
             }
         }

--- a/src/Profiler/Profiler.php
+++ b/src/Profiler/Profiler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Profiler;
 
 /**

--- a/src/Swift/Mailer.php
+++ b/src/Swift/Mailer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Swift;
 
 use Swift_Mailer;

--- a/src/TestCase/CommandTestCase.php
+++ b/src/TestCase/CommandTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\TestCase;
 
 use Symfony\Component\Console\Application;

--- a/src/TestCase/FixturePathTrait.php
+++ b/src/TestCase/FixturePathTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\TestCase;
 
 /**

--- a/src/TestCase/UnitTestCase.php
+++ b/src/TestCase/UnitTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\TestCase;
 
 use PHPUnit\Framework\TestCase;

--- a/src/TestCase/WebTestCase.php
+++ b/src/TestCase/WebTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\TestCase;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/src/Tests/Buzz/ClientTest.php
+++ b/src/Tests/Buzz/ClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Buzz;
 
 use Buzz\Message\Request;

--- a/src/Tests/Doctrine/DBAL/ConnectionTest.php
+++ b/src/Tests/Doctrine/DBAL/ConnectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Doctrine\DBAL;
 
 use TestTools\Fixture\Exception\OfflineException;

--- a/src/Tests/Fixture/FileFixtureTest.php
+++ b/src/Tests/Fixture/FileFixtureTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Fixture;
 
 use TestTools\Fixture\FileFixture;

--- a/src/Tests/Fixture/NotSerializable.php
+++ b/src/Tests/Fixture/NotSerializable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Fixture;
 
 class NotSerializable

--- a/src/Tests/Fixture/NotSerializableException.php
+++ b/src/Tests/Fixture/NotSerializableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Fixture;
 
 class NotSerializableException extends \Exception

--- a/src/Tests/Guzzle/Http/ClientTest.php
+++ b/src/Tests/Guzzle/Http/ClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Guzzle\Http;
 
 use TestTools\TestCase\UnitTestCase;

--- a/src/Tests/Profiler/ProfilerTest.php
+++ b/src/Tests/Profiler/ProfilerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Profiler;
 
 use TestTools\Profiler\Profiler;

--- a/src/Tests/Swift/MailerTest.php
+++ b/src/Tests/Swift/MailerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Swift;
 
 use TestTools\TestCase\UnitTestCase;

--- a/src/Tests/TestCase/UnitTestCaseTest.php
+++ b/src/Tests/TestCase/UnitTestCaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Buzz;
 
 use TestTools\TestCase\UnitTestCase;

--- a/src/Tests/Util/FixedDateTimeTest.php
+++ b/src/Tests/Util/FixedDateTimeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Tests\Util;
 
 use PHPUnit\Framework\TestCase;

--- a/src/Util/FixedDateTime.php
+++ b/src/Util/FixedDateTime.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestTools\Util;
 
 /**


### PR DESCRIPTION
...since this package uses PHP 7 as min version.

Let me know if you'd like it placed somewhere else.

Personally I prefer less attention to it, since it's always the same and everywhere (like `<?php`):

```php
<?php define(strict_types=1);

namespace ...
```